### PR TITLE
[FEAT] API 변경점 대응 v1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ function App() {
       <GlobalLayout>
         <Routes>
           <Route path="/" element={<MainPage />} />
-          <Route path="/summoner/:summonerName" element={<SummonerPage />} />
+          <Route
+            path="/summoner/:summonerName/:tagName"
+            element={<SummonerPage />}
+          />
           <Route path="/ranking" element={<RankingPage />} />
         </Routes>
       </GlobalLayout>

--- a/src/Layouts/Header.tsx
+++ b/src/Layouts/Header.tsx
@@ -31,9 +31,10 @@ export default function Header() {
             value={searchVal}
             onSubmit={() => {
               const val = searchVal.trim();
+              const [name, tag] = val.split("#");
               setSearchVal("");
               addRecentSearchVal(val);
-              navigation(`summoner/${val}`);
+              navigation(`summoner/${name}${tag ? `/${tag}` : "/KR1"}`);
             }}
             placeholder="소환사 검색"
             onChange={(v) => setSearchVal(v)}

--- a/src/Layouts/Header.tsx
+++ b/src/Layouts/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
       <div className="header_inner">
         <h1>
           <Link to="/">
-            <img src="public/logo.png" width={44} />
+            <img src="logo.png" width={44} />
           </Link>
         </h1>
         <div className="header_content">

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -37,9 +37,9 @@ export function useRankingInfo(
   return resp;
 }
 
-export function useSummonerInfo(summonerName: string) {
+export function useSummonerInfo(summonerName: string, tagName: string) {
   const resp = useSWR(
-    `/summoner/${summonerName}`,
+    `/summoner/${summonerName}-${tagName}`,
     (url: string) => {
       return API.get<ISummonerProfile>(url).then((res) => res.data);
     },

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -38,7 +38,7 @@ export default function SearchInput({
           onChange={(e) => onChange(e.target.value)}
         />
         <button className="btn_search" type="submit">
-          <img src="public/search icon.png" width={16} />
+          <img src="search icon.png" width={16} />
         </button>
       </form>
     </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -25,7 +25,7 @@ export default function MainPage() {
         onMouseDown={(e) => {
           e.preventDefault();
         }}
-        to={`summoner/${name}/tag`}
+        to={`summoner/${name}/${tag}`}
         className="recent_search_val"
       >
         <span>{val}</span>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -18,12 +18,14 @@ export default function MainPage() {
   );
 
   function RecentSearch({ val }: { val: string }) {
+    const [name, tag] = val.split("#");
+
     return (
       <Link
         onMouseDown={(e) => {
           e.preventDefault();
         }}
-        to={`summoner/${val}`}
+        to={`summoner/${name}/tag`}
         className="recent_search_val"
       >
         <span>{val}</span>
@@ -49,8 +51,9 @@ export default function MainPage() {
         value={searchVal}
         onSubmit={() => {
           const val = searchVal.trim();
-          addRecentSearchVal(val);
-          navigation(`summoner/${val}`);
+          const [name, tag] = val.split("#");
+          addRecentSearchVal(name + (tag ? `#${tag}` : `#KR1`));
+          navigation(`summoner/${name}${tag ? `/${tag}` : "/KR1"}`);
         }}
         onFocus={() => {
           setShowRecent(true);

--- a/src/pages/SummonerPage.tsx
+++ b/src/pages/SummonerPage.tsx
@@ -10,10 +10,13 @@ import { getFullTierName } from "../utils/generalFunctions";
 import "./SummonerPage.scss";
 
 export default function SummonerPage() {
-  const { summonerName } = useParams();
+  const { summonerName, tagName } = useParams();
   const [gameListData, setGameListData] = useState<ISimpleMatch[]>([]);
   const [isMoreLoading, setIsMoreLoading] = useState(false);
-  const { data, isLoading, isValidating } = useSummonerInfo(summonerName || "");
+  const { data, isLoading, isValidating } = useSummonerInfo(
+    summonerName || "",
+    tagName || ""
+  );
   const pageNumber = useRef(1);
 
   const getMoreGameList = async (puid: string) => {


### PR DESCRIPTION
https://spot-ursinia-1fd.notion.site/2023-12-15-33b68dc8acac4e52af26c8b7693a05cf
대응 기능수정
- 소환사 태그네임에 대한 대응
  - 소환사이름을 검색할 때, 태그를 추가하여 검색할 수 있도록 대응
  - 기본적으로 KR1 태그가 들어가 검색되도록 수정
  - 이에따라 최근검색 기록에도 소환사명+태그명으로 출력되게 변경
  - 이에따라 소환사 전적 페이지의 주소도 변경 ( /summoner/:summonerName -> /summoner/:summonerName/:tagName )
- 일부 이미지가 깨지는 현상 수정

- 추가 대응이 필요한 부분(추후에)
  - /matches/v2/{puuid}에 대한 대응은 아직 완료되지 않음
  - 랭킹/소환사의전적 에서 소환사의 태그명을 주지않아 전적이나 랭킹에서 소환사명을 클릭하여 해당 소환사의 전적으로 가는 기능은 현재 먹통인 상황. api가 고쳐지면 추가 대응해야함 (12/16기준)
