### PR TITLE
[FEAT] : API 변경 대응

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.5.1",
+        "html-react-parser": "^5.0.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
@@ -1296,6 +1297,68 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -1756,6 +1819,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.6.tgz",
+      "integrity": "sha512-6KSMOgxzAIZZ1Tcc6eNEfRFC/XE0+TiYaWanKNYKHSEQOtdxrR0t8ILKXNDcRea/WbIDltLUIP8mi/tw7dtFvQ==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.0.11.tgz",
+      "integrity": "sha512-TcLGDGMbVRbos09zwnom/QrLbd4PmNFhMEhlp2ZdHBboAuCuctRDqr8JU5aTyKzFKotdpSg8QkXVxVb5ZUU2Ag==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.6",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.10"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1811,6 +1915,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
+      "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2278,6 +2387,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-router": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
@@ -2494,6 +2608,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.10.tgz",
+      "integrity": "sha512-VC7MBJa+y0RZhpnLKDPmVRLRswsASLmixkiZ5R8xZpNT9VyjeRzwnXd2pBzAWdgSGv/pCNNH01gPCCUsB9exYg==",
+      "dependencies": {
+        "style-to-object": "1.0.5"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
+      "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
+      "dependencies": {
+        "inline-style-parser": "0.2.2"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.5.1",
+    "html-react-parser": "^5.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
             path="/summoner/:summonerName/:tagName"
             element={<SummonerPage />}
           />
+          <Route path="/summoner/:id" element={<SummonerPage />} />
           <Route path="/ranking" element={<RankingPage />} />
           <Route
             path="/test"

--- a/src/Layouts/Header.tsx
+++ b/src/Layouts/Header.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import SearchInput from "../components/SearchInput";
 import { MENU_LIST } from "../constants/Enum";
-import { addRecentSearchVal } from "../utils/generalFunctions";
+import { addRecentSearchVal, makeTagName } from "../utils/generalFunctions";
 import { useOnClickOutside } from "../utils/useOnClickOutside";
 import useUser from "../utils/useUser";
 import "./Header.scss";
@@ -64,11 +64,10 @@ export default function Header() {
             <SearchInput
               value={searchVal}
               onSubmit={() => {
-                const val = searchVal.trim();
-                const [name, tag] = val.split("#");
+                const { name, tag } = makeTagName(searchVal);
                 setSearchVal("");
-                addRecentSearchVal(name + (tag ? `#${tag}` : `#KR1`));
-                navigation(`summoner/${name}${tag ? `/${tag}` : "/KR1"}`);
+                addRecentSearchVal(name, tag);
+                navigation(`summoner/${name}/${tag}`);
               }}
               placeholder="소환사 검색"
               onChange={(v) => setSearchVal(v)}

--- a/src/Layouts/Header.tsx
+++ b/src/Layouts/Header.tsx
@@ -67,7 +67,7 @@ export default function Header() {
                 const val = searchVal.trim();
                 const [name, tag] = val.split("#");
                 setSearchVal("");
-                addRecentSearchVal(val);
+                addRecentSearchVal(name + (tag ? `#${tag}` : `#KR1`));
                 navigation(`summoner/${name}${tag ? `/${tag}` : "/KR1"}`);
               }}
               placeholder="소환사 검색"

--- a/src/Layouts/MultiTabLayout.scss
+++ b/src/Layouts/MultiTabLayout.scss
@@ -33,7 +33,7 @@
   .tab_page_list {
     padding: 12px;
 
-    .tab_Page {
+    .tab_page {
       display: none;
       &.visible {
         display: block;

--- a/src/Layouts/MultiTabLayout.tsx
+++ b/src/Layouts/MultiTabLayout.tsx
@@ -23,7 +23,18 @@ export default function MultiTabLayout({ tabList, tabPageList }: IProp) {
           );
         })}
       </div>
-      <div className="tab_page_list">{tabPageList[tabIdx]}</div>
+      <div className="tab_page_list">
+        {tabPageList.map((v, i) => {
+          return (
+            <div
+              className={`tab_page ${i === tabIdx ? "visible" : ""}`}
+              key={`tab_page_${v}_${i}`}
+            >
+              {v}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -38,9 +38,37 @@ export function useRankingInfo(
   return resp;
 }
 
-export function useSummonerInfo(summonerName: string, tagName: string) {
+export function useSummonerInfo(summonerName?: string, tagName?: string) {
   const resp = useSWR(
-    `/summoner/${summonerName}-${tagName}`,
+    summonerName && tagName ? `/summoner/${summonerName}-${tagName}` : null,
+    (url: string) => {
+      return API.get<ISummonerProfile>(url).then((res) => res.data);
+    },
+    {
+      revalidateOnFocus: false,
+    }
+  );
+
+  return resp;
+}
+
+export function useSummonerInfoById(summonerId: string) {
+  const resp = useSWR(
+    summonerId ? `/summoner/summonerId/${summonerId}` : null,
+    (url: string) => {
+      return API.get<ISummonerProfile>(url).then((res) => res.data);
+    },
+    {
+      revalidateOnFocus: false,
+    }
+  );
+
+  return resp;
+}
+
+export function useSummonerInfoByPuuid(puuid: string) {
+  const resp = useSWR(
+    puuid ? `/summoner/puuid/${puuid}` : null,
     (url: string) => {
       return API.get<ISummonerProfile>(url).then((res) => res.data);
     },

--- a/src/api/apis.ts
+++ b/src/api/apis.ts
@@ -52,7 +52,7 @@ export function useSummonerInfo(summonerName?: string, tagName?: string) {
   return resp;
 }
 
-export function useSummonerInfoById(summonerId: string) {
+export function useSummonerInfoById(summonerId?: string) {
   const resp = useSWR(
     summonerId ? `/summoner/summonerId/${summonerId}` : null,
     (url: string) => {
@@ -66,7 +66,7 @@ export function useSummonerInfoById(summonerId: string) {
   return resp;
 }
 
-export function useSummonerInfoByPuuid(puuid: string) {
+export function useSummonerInfoByPuuid(puuid?: string) {
   const resp = useSWR(
     puuid ? `/summoner/puuid/${puuid}` : null,
     (url: string) => {

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -12,6 +12,15 @@ interface IProps {
 export default function MatchComponent({ matchData, userName }: IProps) {
   const [show, setShow] = useState(false);
   const { matchId, queueId, participants } = matchData;
+  const sortedParticipants = participants.sort((a, b) => {
+    if (b.win && !a.win) {
+      return 1;
+    }
+    if (!b.win && a.win) {
+      return -1;
+    }
+    return 0;
+  });
 
   const target = participants.find((v) => v.summonerName === userName)!;
   // 승/패 팀 나누어서 표기 할것 => 두 팀을 나누어서 변수화 해라
@@ -132,7 +141,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
       {show ? (
         <div className="match_detail_wrapper">
           <div className="match_detail">
-            {participants.slice(0, 5).map((v) => (
+            {sortedParticipants.slice(0, 5).map((v) => (
               <ParticipantComponent
                 key={`${v.summonerName}+${matchId}`}
                 {...v}
@@ -140,7 +149,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
             ))}
           </div>
           <div className="match_detail">
-            {participants.slice(5).map((v) => (
+            {sortedParticipants.slice(5).map((v) => (
               <ParticipantComponent
                 key={`${v.summonerName}+${matchId}`}
                 {...v}

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -48,7 +48,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
           <ObjImgComponent {...target.subRune} src={target.subRune.image} />
         </div>
         <div className="summoner_info_wrapper wrapper">
-          <Link to={`/summoner/${target.summonerName}`}>
+          <Link to={`/summoner/${target.summonerId}`}>
             {target.summonerName}
           </Link>
           <span className="summoner_level">{`Level ${target.summonerLevel}`}</span>

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -141,20 +141,24 @@ export default function MatchComponent({ matchData, userName }: IProps) {
       {show ? (
         <div className="match_detail_wrapper">
           <div className="match_detail">
-            {sortedParticipants.slice(0, 5).map((v) => (
-              <ParticipantComponent
-                key={`${v.summonerName}+${matchId}`}
-                {...v}
-              />
-            ))}
+            {sortedParticipants
+              .slice(0, sortedParticipants.length / 2)
+              .map((v) => (
+                <ParticipantComponent
+                  key={`${v.summonerName}+${matchId}`}
+                  {...v}
+                />
+              ))}
           </div>
           <div className="match_detail">
-            {sortedParticipants.slice(5).map((v) => (
-              <ParticipantComponent
-                key={`${v.summonerName}+${matchId}`}
-                {...v}
-              />
-            ))}
+            {sortedParticipants
+              .slice(sortedParticipants.length / 2)
+              .map((v) => (
+                <ParticipantComponent
+                  key={`${v.summonerName}+${matchId}`}
+                  {...v}
+                />
+              ))}
           </div>
         </div>
       ) : (

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -36,12 +36,16 @@ export default function MatchComponent({ matchData, userName }: IProps) {
         </div>
         <div className="spell_wrapper wrapper">
           {target.spells.map((v, i) => (
-            <ObjImgComponent key={`spell-${target.summonerName}-${i}`} {...v} />
+            <ObjImgComponent
+              key={`spell-${target.summonerName}-${i}`}
+              {...v}
+              src={v.image}
+            />
           ))}
         </div>
         <div className="rune_wrapper wrapper">
-          <ObjImgComponent {...target.mainRune} />
-          <ObjImgComponent {...target.subRune} />
+          <ObjImgComponent {...target.mainRune} src={target.mainRune.image} />
+          <ObjImgComponent {...target.subRune} src={target.subRune.image} />
         </div>
         <div className="summoner_info_wrapper wrapper">
           <Link to={`/summoner/${target.summonerName}`}>
@@ -62,7 +66,13 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                   key={matchId + userName + v.name + i}
                   className="item_icon"
                 >
-                  {v && <ObjImgComponent {...v} description={v.plaintext} />}
+                  {v && (
+                    <ObjImgComponent
+                      {...v}
+                      description={v.plaintext}
+                      src={v.image}
+                    />
+                  )}
                 </div>
               );
             }
@@ -96,12 +106,16 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                 <ObjImgComponent
                   key={`spell-${target.summonerName}-${i}`}
                   {...v}
+                  src={v.image}
                 />
               ))}
             </div>
             <div className="rune_wrapper wrapper">
-              <ObjImgComponent {...target.mainRune} />
-              <ObjImgComponent {...target.subRune} />
+              <ObjImgComponent
+                {...target.mainRune}
+                src={target.mainRune.image}
+              />
+              <ObjImgComponent {...target.subRune} src={target.subRune.image} />
             </div>
             <div className="kda_wrapper">
               <span>{target.kills} /</span>
@@ -117,7 +131,11 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                       className="item_icon"
                     >
                       {v && (
-                        <ObjImgComponent {...v} description={v.plaintext} />
+                        <ObjImgComponent
+                          {...v}
+                          description={v.plaintext}
+                          src={v.image}
+                        />
                       )}
                     </div>
                   );

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -69,7 +69,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                   {v && (
                     <ObjImgComponent
                       {...v}
-                      description={v.plaintext}
+                      description={v.description}
                       src={v.image}
                     />
                   )}
@@ -133,7 +133,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                       {v && (
                         <ObjImgComponent
                           {...v}
-                          description={v.plaintext}
+                          description={v.description}
                           src={v.image}
                         />
                       )}

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -53,8 +53,12 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                   key={matchId + userName + v.name + i}
                   className="item_icon"
                 >
-                  {v.image && (
-                    <ObjImgComponent {...v} description={v.plaintext} />
+                  {v.imageUrl && (
+                    <ObjImgComponent
+                      {...v}
+                      image={v.imageUrl}
+                      description={v.plaintext}
+                    />
                   )}
                 </div>
               );
@@ -109,8 +113,12 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                       key={matchId + userName + v.name + i}
                       className="item_icon"
                     >
-                      {v.image && (
-                        <ObjImgComponent {...v} description={v.plaintext} />
+                      {v.imageUrl && (
+                        <ObjImgComponent
+                          {...v}
+                          image={v.imageUrl}
+                          description={v.plaintext}
+                        />
                       )}
                     </div>
                   );

--- a/src/components/MatchComponent.tsx
+++ b/src/components/MatchComponent.tsx
@@ -53,13 +53,7 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                   key={matchId + userName + v.name + i}
                   className="item_icon"
                 >
-                  {v.imageUrl && (
-                    <ObjImgComponent
-                      {...v}
-                      image={v.imageUrl}
-                      description={v.plaintext}
-                    />
-                  )}
+                  {v && <ObjImgComponent {...v} description={v.plaintext} />}
                 </div>
               );
             }
@@ -113,12 +107,8 @@ export default function MatchComponent({ matchData, userName }: IProps) {
                       key={matchId + userName + v.name + i}
                       className="item_icon"
                     >
-                      {v.imageUrl && (
-                        <ObjImgComponent
-                          {...v}
-                          image={v.imageUrl}
-                          description={v.plaintext}
-                        />
+                      {v && (
+                        <ObjImgComponent {...v} description={v.plaintext} />
                       )}
                     </div>
                   );

--- a/src/components/MatchesComponent.tsx
+++ b/src/components/MatchesComponent.tsx
@@ -18,16 +18,14 @@ interface IProp {
 const MatchesComponent = React.memo(({ data, q }: IProp) => {
   const pageNumber = useRef(1);
   const [gameListData, setGameListData] = useState<ISimpleMatch[]>(
-    data.matches
+    filtering(data.matches)
   );
   const [isMoreLoading, setIsMoreLoading] = useState(false);
   const [userGameList, setUserGameList] = useState<ISimpleParticipant[]>([]);
 
   function filtering(data: ISimpleMatch[]) {
-    // console.log("inside filtering func", data);
     return q ? data.filter((t) => t.queueId === q) : data;
   }
-  // console.log(userGameList, q, data);
 
   useEffect(() => {
     const target = filtering(gameListData);
@@ -42,7 +40,6 @@ const MatchesComponent = React.memo(({ data, q }: IProp) => {
         temp.push(ttarget);
       }
     });
-    console.log("inside ue", target, q, userGameList, temp);
 
     setUserGameList(temp);
   }, [gameListData, q, data]);
@@ -96,11 +93,6 @@ const MatchesComponent = React.memo(({ data, q }: IProp) => {
       </div>
     </div>
   );
-}, propsAreEqual);
-
-function propsAreEqual(prev: Readonly<IProp>, next: Readonly<IProp>) {
-  console.log(prev.q === next.q);
-  return prev.q === next.q;
-}
+});
 
 export default MatchesComponent;

--- a/src/components/MatchesComponent.tsx
+++ b/src/components/MatchesComponent.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef, useState } from "react";
+import { GetGameList } from "../api/apis";
+import {
+  IQueueId,
+  ISimpleMatch,
+  ISimpleParticipant,
+  ISummonerProfile,
+} from "../types/types";
+import Loading from "./Loading";
+import MatchComponent from "./MatchComponent";
+import UserRecentInfoComponent from "./UserRecentInfoComponent";
+
+interface IProp {
+  data: ISummonerProfile;
+  q?: IQueueId;
+}
+
+const MatchesComponent = React.memo(({ data, q }: IProp) => {
+  const pageNumber = useRef(1);
+  const [gameListData, setGameListData] = useState<ISimpleMatch[]>(
+    data.matches
+  );
+  const [isMoreLoading, setIsMoreLoading] = useState(false);
+  const [userGameList, setUserGameList] = useState<ISimpleParticipant[]>([]);
+
+  function filtering(data: ISimpleMatch[]) {
+    // console.log("inside filtering func", data);
+    return q ? data.filter((t) => t.queueId === q) : data;
+  }
+  // console.log(userGameList, q, data);
+
+  useEffect(() => {
+    const target = filtering(gameListData);
+    const temp: ISimpleParticipant[] = [];
+    target.forEach((v) => {
+      const ttarget = v.participants.find(
+        (t) =>
+          t.summonerName.toLowerCase() ===
+          data.profile.summonerName.toLowerCase()
+      );
+      if (ttarget) {
+        temp.push(ttarget);
+      }
+    });
+    console.log("inside ue", target, q, userGameList, temp);
+
+    setUserGameList(temp);
+  }, [gameListData, q, data]);
+
+  const getMoreGameList = async (puid: string) => {
+    const targetNumber = pageNumber.current + 1;
+    const gameData = await GetGameList(puid, targetNumber);
+    if (gameData) {
+      setGameListData(filtering([...gameListData, ...gameData.data]));
+      pageNumber.current = pageNumber.current + 1;
+      setIsMoreLoading(false);
+    }
+  };
+
+  return (
+    <div className="summoner_detail_wrapper">
+      <UserRecentInfoComponent userData={userGameList} />
+      <div className="matches_container">
+        {gameListData.length !== 0 ? (
+          <>
+            {filtering(gameListData).map((v) => {
+              return (
+                <MatchComponent
+                  key={v.matchId}
+                  matchData={v}
+                  userName={data.profile.summonerName}
+                />
+              );
+            })}
+            <div className="more_match">
+              {isMoreLoading ? (
+                <Loading width={32} />
+              ) : (
+                <button
+                  onClick={() => {
+                    setIsMoreLoading(true);
+                    getMoreGameList(data.profile.puuid);
+                  }}
+                  type="button"
+                >
+                  더보기
+                </button>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="summoner_detail_wrapper">
+            매칭기록이 존재하지 않습니다.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}, propsAreEqual);
+
+function propsAreEqual(prev: Readonly<IProp>, next: Readonly<IProp>) {
+  console.log(prev.q === next.q);
+  return prev.q === next.q;
+}
+
+export default MatchesComponent;

--- a/src/components/ObjImgComponent.tsx
+++ b/src/components/ObjImgComponent.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import parse from "html-react-parser";
+import React, { useState } from "react";
 import "./ObjImgComponent.scss";
 
 interface IProp extends React.ImgHTMLAttributes<HTMLImageElement> {
@@ -22,7 +23,7 @@ export default function ObjImgComponent({ name, description, ...rest }: IProp) {
       {showDesc && description && (
         <div className="obj_description">
           <span className="obj_name">{name}</span>
-          <span>{description}</span>
+          <span>{parse(description)}</span>
         </div>
       )}
     </div>

--- a/src/components/ObjImgComponent.tsx
+++ b/src/components/ObjImgComponent.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import "./ObjImgComponent.scss";
 
-interface IProp {
+interface IProp extends React.ImgHTMLAttributes<HTMLImageElement> {
   name: string;
   description: string;
   image: string;
 }
 
-export default function ObjImgComponent({ name, description, image }: IProp) {
+export default function ObjImgComponent({ name, description, ...rest }: IProp) {
   const [showDesc, setShowDesc] = useState(false);
 
   return (
@@ -15,8 +15,9 @@ export default function ObjImgComponent({ name, description, image }: IProp) {
       <img
         onMouseEnter={() => setShowDesc(true)}
         onMouseLeave={() => setShowDesc(false)}
-        src={image}
+        src={rest.src}
         alt={name}
+        {...rest}
       />
       {showDesc && (
         <div className="obj_description">

--- a/src/components/ObjImgComponent.tsx
+++ b/src/components/ObjImgComponent.tsx
@@ -19,7 +19,7 @@ export default function ObjImgComponent({ name, description, ...rest }: IProp) {
         alt={name}
         {...rest}
       />
-      {showDesc && (
+      {showDesc && description && (
         <div className="obj_description">
           <span className="obj_name">{name}</span>
           <span>{description}</span>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,6 +4,7 @@ import SearchInput from "../components/SearchInput";
 import {
   addRecentSearchVal,
   deleteRecentSearchVal,
+  makeTagName,
 } from "../utils/generalFunctions";
 import "./MainPage.scss";
 
@@ -50,10 +51,9 @@ export default function MainPage() {
       <SearchInput
         value={searchVal}
         onSubmit={() => {
-          const val = searchVal.trim();
-          const [name, tag] = val.split("#");
-          addRecentSearchVal(name + (tag ? `#${tag}` : `#KR1`));
-          navigation(`summoner/${name}${tag ? `/${tag}` : "/KR1"}`);
+          const { name, tag } = makeTagName(searchVal);
+          addRecentSearchVal(name, tag);
+          navigation(`summoner/${name}/${tag}`);
         }}
         onFocus={() => {
           setShowRecent(true);

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -91,7 +91,7 @@ export default function RankingPage() {
                           </td>
                           <td
                             onClick={() =>
-                              navigator(`/summoner/${v.summonerName}`)
+                              navigator(`/summoner/${v.summonerId}`)
                             }
                             className="ranker_td"
                           >

--- a/src/pages/SummonerPage.scss
+++ b/src/pages/SummonerPage.scss
@@ -42,9 +42,13 @@
 
         .summoner_name {
           display: flex;
+          flex-direction: column;
           align-items: center;
           font-size: 1.8rem;
           font-weight: 600;
+          .summoner_tag {
+            color: $color-dark-border;
+          }
         }
       }
 

--- a/src/pages/SummonerPage.tsx
+++ b/src/pages/SummonerPage.tsx
@@ -1,22 +1,29 @@
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import MultiTabLayout from "../Layouts/MultiTabLayout";
-import { GetGameList, useSummonerInfo } from "../api/apis";
+import { GetGameList, useSummonerInfo, useSummonerInfoById } from "../api/apis";
 import Loading from "../components/Loading";
 import MatchComponent from "../components/MatchComponent";
 import UserRecentInfoComponent from "../components/UserRecentInfoComponent";
-import { ILeagueEntry, ISimpleMatch, ISimpleParticipant } from "../types/types";
+import {
+  ILeagueEntry,
+  IProfile,
+  IQueueId,
+  ISimpleMatch,
+  ISimpleParticipant,
+  ISummonerProfile,
+} from "../types/types";
 import { getFullTierName } from "../utils/generalFunctions";
 import "./SummonerPage.scss";
 
 export default function SummonerPage() {
-  const { summonerName, tagName } = useParams();
+  const { summonerName, tagName, id } = useParams();
   const [gameListData, setGameListData] = useState<ISimpleMatch[]>([]);
+  const [summonerProfileData, setSummonerProfileData] = useState<IProfile>();
   const [isMoreLoading, setIsMoreLoading] = useState(false);
-  const { data, isLoading, isValidating } = useSummonerInfo(
-    summonerName || "",
-    tagName || ""
-  );
+  const dataByName = useSummonerInfo(summonerName, tagName);
+  const dataById = useSummonerInfoById(id);
+
   const pageNumber = useRef(1);
 
   const getMoreGameList = async (puid: string) => {
@@ -30,10 +37,36 @@ export default function SummonerPage() {
   };
 
   useEffect(() => {
-    if (!isLoading && !isValidating && data?.matches) {
-      setGameListData(data.matches);
+    if (
+      !dataByName.isLoading &&
+      !dataByName.isValidating &&
+      dataByName.data?.matches
+    ) {
+      setGameListData(dataByName.data.matches);
+      setSummonerProfileData(dataByName.data.profile);
     }
-  }, [isLoading, isValidating, data?.matches]);
+  }, [
+    dataByName.isLoading,
+    dataByName.isValidating,
+    dataByName.data?.matches,
+    dataByName.data?.profile,
+  ]);
+
+  useEffect(() => {
+    if (
+      !dataById.isLoading &&
+      !dataById.isValidating &&
+      dataById.data?.matches
+    ) {
+      setGameListData(dataById.data.matches);
+      setSummonerProfileData(dataById.data.profile);
+    }
+  }, [
+    dataById.isLoading,
+    dataById.isValidating,
+    dataById.data?.matches,
+    dataById.data?.profile,
+  ]);
 
   const LeagueComponent = (props: ILeagueEntry) => {
     const qType = props.queueType === "RANKED_SOLO" ? "솔로 랭크" : "자유 랭크";
@@ -69,10 +102,14 @@ export default function SummonerPage() {
     );
   };
 
-  function MatchComp(matchData: ISimpleMatch[], userName: string) {
-    const target = matchData;
+  function MatchComp(
+    targetData: ISimpleMatch[],
+    profileData?: IProfile,
+    v?: IQueueId
+  ) {
+    const target = v ? targetData.filter((t) => t.queueId === v) : targetData;
+    const userName = profileData?.summonerName || "";
     const temp: ISimpleParticipant[] = [];
-
     if (target.length === 0) {
       return (
         <div className="summoner_detail_wrapper">
@@ -109,7 +146,7 @@ export default function SummonerPage() {
               <button
                 onClick={() => {
                   setIsMoreLoading(true);
-                  getMoreGameList(data!.profile.puuid);
+                  getMoreGameList(profileData?.puuid || "");
                 }}
                 type="button"
               >
@@ -122,53 +159,55 @@ export default function SummonerPage() {
     );
   }
 
+  function SummonerProfile(data: ISummonerProfile) {
+    return (
+      <>
+        <div className="summoner_summary_wrapper">
+          <div className="summoner_profile">
+            <div className="summoner_icon">
+              <img src={data.profile.profileIcon} alt="소환사아이콘" />
+              <span>{data.profile.summonerLevel}</span>
+            </div>
+            <div className="summoner_name">
+              <span>{data.profile.summonerName}</span>
+            </div>
+          </div>
+          <div className="summoner_league_container">
+            {LeagueComponent(data.profile.soloLeagueEntry)}
+            {LeagueComponent(data.profile.flexLeagueEntry)}
+          </div>
+        </div>
+        <div className="multi_tab_wrapper">
+          <MultiTabLayout
+            tabList={["전체", "솔로 랭크", "자유 랭크", "기타"]}
+            tabPageList={[
+              MatchComp(gameListData, summonerProfileData),
+              MatchComp(gameListData, summonerProfileData, "SOLO_RANK_GAME"),
+              MatchComp(gameListData, summonerProfileData, "FLEX_RANK_GAME"),
+              MatchComp(
+                gameListData.filter(
+                  (v) =>
+                    v.queueId !== "FLEX_RANK_GAME" &&
+                    v.queueId !== "SOLO_RANK_GAME"
+                ),
+                summonerProfileData
+              ),
+            ]}
+          />
+        </div>
+      </>
+    );
+  }
+
   return (
     <div className="page_summoner">
       <div className="page_summoner_wrapper">
-        {isLoading ? (
-          <Loading width={32} />
-        ) : data ? (
-          <>
-            <div className="summoner_summary_wrapper">
-              <div className="summoner_profile">
-                <div className="summoner_icon">
-                  <img src={data.profile.profileIcon} alt="소환사아이콘" />
-                  <span>{data.profile.summonerLevel}</span>
-                </div>
-                <div className="summoner_name">
-                  <span>{data.profile.summonerName}</span>
-                </div>
-              </div>
-              <div className="summoner_league_container">
-                {LeagueComponent(data.profile.soloLeagueEntry)}
-                {LeagueComponent(data.profile.flexLeagueEntry)}
-              </div>
-            </div>
-            <div className="multi_tab_wrapper">
-              <MultiTabLayout
-                tabList={["전체", "솔로 랭크", "자유 랭크", "기타"]}
-                tabPageList={[
-                  MatchComp(gameListData, data.profile.summonerName),
-                  MatchComp(
-                    gameListData.filter((v) => v.queueId === "SOLO_RANK_GAME"),
-                    data.profile.summonerName
-                  ),
-                  MatchComp(
-                    gameListData.filter((v) => v.queueId === "FLEX_RANK_GAME"),
-                    data.profile.summonerName
-                  ),
-                  MatchComp(
-                    gameListData.filter(
-                      (v) =>
-                        v.queueId !== "FLEX_RANK_GAME" &&
-                        v.queueId !== "SOLO_RANK_GAME"
-                    ),
-                    data.profile.summonerName
-                  ),
-                ]}
-              />
-            </div>
-          </>
+        {dataByName.isLoading || dataById.isLoading ? (
+          <Loading width={18} />
+        ) : dataByName.data ? (
+          <SummonerProfile {...dataByName.data} />
+        ) : dataById.data ? (
+          <SummonerProfile {...dataById.data} />
         ) : (
           <div className="no_summoner_exists">
             존재하지 않는 소환사 입니다. 소환사 명을 다시 확인해 주세요.

--- a/src/pages/SummonerPage.tsx
+++ b/src/pages/SummonerPage.tsx
@@ -170,6 +170,7 @@ export default function SummonerPage() {
             </div>
             <div className="summoner_name">
               <span>{data.profile.summonerName}</span>
+              <span className="summoner_tag">{`#${data.profile.tagLine}`}</span>
             </div>
           </div>
           <div className="summoner_league_container">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -78,7 +78,7 @@ export interface IChampion {
 }
 export interface IItem {
   name: string;
-  plaintext: string;
+  description: string;
   image: string;
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -30,6 +30,8 @@ export interface ILeagueEntry {
 
 export interface IProfile {
   puuid: string;
+  gameName: string;
+  tagLine: string;
   summonerName: string;
   summonerLevel: number;
   profileIcon: string;
@@ -38,22 +40,21 @@ export interface IProfile {
 }
 
 export interface ISimpleParticipant {
+  summonerId: string;
   summonerName: string;
   summonerLevel: number;
-  championLevel: number;
-  lane: string;
-  role: string;
-  teamId: number;
   kills: number;
   deaths: number;
   assists: number;
-  summoner1Casts: number;
-  summoner2Casts: number;
+  goldEarned: number;
+  goldSpent: number;
+  teamId: number;
   items: IItem[];
   spells: ISpell[];
   mainRune: IRune;
   subRune: IRune;
   champion: IChampion;
+  championLevel: number;
   win: boolean;
 }
 
@@ -78,7 +79,7 @@ export interface IChampion {
 export interface IItem {
   name: string;
   plaintext: string;
-  image: string;
+  imageUrl: string;
 }
 
 export interface ISpell {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -79,7 +79,7 @@ export interface IChampion {
 export interface IItem {
   name: string;
   plaintext: string;
-  imageUrl: string;
+  image: string;
 }
 
 export interface ISpell {

--- a/src/utils/generalFunctions.ts
+++ b/src/utils/generalFunctions.ts
@@ -77,11 +77,12 @@ export function getGameType(queueType: IQueueId) {
   }
 }
 
-export function addRecentSearchVal(val: string) {
+export function addRecentSearchVal(name: string, tag: string) {
   const temp = localStorage.getItem("recent");
+  const tempVal = name + `#${tag}`;
   const ttemp = temp ? (JSON.parse(temp) as string[]) : [];
-  const tttemp = ttemp.filter((v) => v !== val);
-  tttemp.unshift(val);
+  const tttemp = ttemp.filter((v) => v !== tempVal);
+  tttemp.unshift(tempVal);
   localStorage.setItem("recent", JSON.stringify(tttemp));
 }
 
@@ -90,4 +91,10 @@ export function deleteRecentSearchVal(val: string) {
   const ttemp = temp ? (JSON.parse(temp) as string[]) : [];
   const tttemp = ttemp.filter((v) => v !== val);
   localStorage.setItem("recent", JSON.stringify(tttemp));
+}
+
+export function makeTagName(val: string) {
+  const searchVal = val.trim();
+  const [name, tag] = searchVal.split("#");
+  return { name, tag: tag ? `${tag}` : "KR1" };
 }


### PR DESCRIPTION
- API 변경점 대응
  - API 사양이 변경됨에 따라 이에 대응하였습니다.
  - 소환사 이름 뿐 아니라 puid 를 통해서도 전적을 불러올 수 있게 대응
  - 이에 따라 랭킹페이지와 전적상세 보기에서도 해당 소환사의 전적을 볼 수 있게 수정

- 리팩토링
  - 소환사 전적 페이지 구조 변경
    - MultitabLayout 을 사용하는 구조 변경
    - 더보기 기능 각 컴포넌트에게 위임
  - ObjImgComponent 에 Img 태그의 기본 속성 위임
  - 아이템 설명이 HTML String 으로 오는 것 컴포넌트화 (진행중)

- 버그수정
  - 전적 상세보기에서 팀이 제대로 구분되지 않던 현상 수정